### PR TITLE
UHF-193 Cache invalidation

### DIFF
--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -5,8 +5,8 @@
  * Admin tools.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\locale\SourceString;
 
 /**
  * Implements hook_toolbar_alter()
@@ -42,7 +42,7 @@ function hdbt_admin_tools_form_config_translation_form_alter(&$form, &$form_stat
 }
 
 function _hdbt_admin_tools_config_translation_form_submit(array $form, FormStateInterface $form_state) {
-  \Drupal\Core\Cache\Cache::invalidateTags([
+  Cache::invalidateTags([
     'config:block.block.footertopblock',
   ]);
 }

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -5,6 +5,7 @@
  * Admin tools.
  */
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\locale\SourceString;
 
 /**
@@ -34,5 +35,14 @@ function hdbt_admin_tools_form_config_translation_form_alter(&$form, &$form_stat
     $settings['footer_settings']['footer_top_content']['#open'] = TRUE;
     $settings['footer_settings']['footer_color']['#disabled'] = TRUE;
     $settings['koro_settings']['koro']['#disabled'] = TRUE;
+
+    // Custom submit callback to invalidate caches.
+    $form['#submit'][] = '_hdbt_admin_tools_config_translation_form_submit';
   }
+}
+
+function _hdbt_admin_tools_config_translation_form_submit(array $form, FormStateInterface $form_state) {
+  \Drupal\Core\Cache\Cache::invalidateTags([
+    'config:block.block.footertopblock',
+  ]);
 }

--- a/modules/hdbt_admin_tools/src/Form/SiteSettings.php
+++ b/modules/hdbt_admin_tools/src/Form/SiteSettings.php
@@ -139,7 +139,7 @@ class SiteSettings extends ConfigFormBase {
       'hdbt_settings:koro',
       'hdbt_settings:footer_color',
     ]);
-    \Drupal\Core\Cache\Cache::invalidateTags([
+    Cache::invalidateTags([
       'config:block.block.footertopblock',
     ]);
   }

--- a/modules/hdbt_admin_tools/src/Form/SiteSettings.php
+++ b/modules/hdbt_admin_tools/src/Form/SiteSettings.php
@@ -7,6 +7,7 @@ namespace Drupal\hdbt_admin_tools\Form;
  * Contains Drupal\hdbt_admin_tools\Form\SiteHeaderSettings.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -137,6 +138,9 @@ class SiteSettings extends ConfigFormBase {
     \Drupal::cache()->invalidateMultiple([
       'hdbt_settings:koro',
       'hdbt_settings:footer_color',
+    ]);
+    \Drupal\Core\Cache\Cache::invalidateTags([
+      'config:block.block.footertopblock',
     ]);
   }
 


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- Switch to corresponding branches: 
   - `composer require drupal/hdbt_admin:dev-UHF-193_invalidate_caches`
- Run `make new`
- Log in to the site.
- In an incognito window or another browser load https://hel-platform.docker.sh/sv
- In logged in window go to https://hel-platform.docker.sh/fi/admin/tools/site-settings/translate/sv/add
   - Add translations to each field what you can translate
   - Save the changes
- Switch to the incognito window and reload the page (no hard reload or such thing)
   - Make sure your translations have appeared to the site.