### PR TITLE
UHF-3160 List of links fix

### DIFF
--- a/modules/hdbt_admin_editorial/src/Plugin/Field/FieldWidget/LinkTargetFieldWidget.php
+++ b/modules/hdbt_admin_editorial/src/Plugin/Field/FieldWidget/LinkTargetFieldWidget.php
@@ -66,12 +66,15 @@ class LinkTargetFieldWidget extends LinkitWidget {
       // TL;DR www.hel.fi/helsinki/old-page becomes /helsinki/old-page and
       // helfi_proxy module converts it to /fi/site-prefix/helsinki/old-page.
       // @see https://helsinkisolutionoffice.atlassian.net/browse/UHF-2919.
-      if (!UrlHelper::externalIsLocal($value['uri'], \Drupal::request()->getSchemeAndHttpHost())) {
+      if (
+        parse_url($value['uri'], PHP_URL_HOST) &&
+        !UrlHelper::externalIsLocal($value['uri'], \Drupal::request()->getSchemeAndHttpHost())
+      ) {
         $value['uri'] = LinkitHelper::uriFromUserInput($value['uri']);
       }
       $value += ['options' => []];
     }
-    return $values;
+    return parent::massageFormValues($values, $form, $form_state);
   }
 
   /**


### PR DESCRIPTION
Fixed whitescreen caused by invalid parameter on function call

Use any existing site
1. `composer require drupal/hdbt_admin:dev-UHF-3160_listoflinks_fix`
2. make drush-cr
3. Go to /node/8/edit
(open inspector, look for ajax errors)
4. Open the first item in list of links paragraph
5. Change the link from /node/1 to (f.ex) /node/8
6. Save
- Expected result: no whitescreen, no ajax errors, the link on the page is ok.

7. Go back to edit
8. Set external link as the first link in list of links paragraph
9. Save
10. Check the first link on the page, it should be OK
- Expected result: no whitescreen, no ajax errors, the link on the page is ok.
