### PR TITLE
UHF-4227: Removed hdbt linkit customizations since we process links in api_base module now

### DIFF
--- a/modules/hdbt_admin_editorial/src/Plugin/Field/FieldWidget/LinkTargetFieldWidget.php
+++ b/modules/hdbt_admin_editorial/src/Plugin/Field/FieldWidget/LinkTargetFieldWidget.php
@@ -4,11 +4,9 @@ declare(strict_types = 1);
 
 namespace Drupal\hdbt_admin_editorial\Plugin\Field\FieldWidget;
 
-use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\linkit\Plugin\Field\FieldWidget\LinkitWidget;
-use Drupal\linkit\Utility\LinkitHelper;
 
 /**
  * Plugin implementation of the 'link_target_field_widget' widget.

--- a/modules/hdbt_admin_editorial/src/Plugin/Field/FieldWidget/LinkTargetFieldWidget.php
+++ b/modules/hdbt_admin_editorial/src/Plugin/Field/FieldWidget/LinkTargetFieldWidget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\hdbt_admin_editorial\Plugin\Field\FieldWidget;
 
 use Drupal\Component\Utility\UrlHelper;
@@ -47,34 +49,6 @@ class LinkTargetFieldWidget extends LinkitWidget {
     ];
 
     return $element;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function massageFormValues(
-    array $values,
-    array $form,
-    FormStateInterface $form_state
-  ) {
-    foreach ($values as &$value) {
-      // Linkit module performs a check if given external domain points to
-      // same domain and converts it to relative if it does.
-      // This breaks all links between different hel.fi instances because all
-      // hel.fi links are converted to relative and helfi_proxy module adds a
-      // 'site prefix' to all non-absolute URLs.
-      // TL;DR www.hel.fi/helsinki/old-page becomes /helsinki/old-page and
-      // helfi_proxy module converts it to /fi/site-prefix/helsinki/old-page.
-      // @see https://helsinkisolutionoffice.atlassian.net/browse/UHF-2919.
-      if (
-        !UrlHelper::isExternal($value['uri']) ||
-        !UrlHelper::externalIsLocal($value['uri'], \Drupal::request()->getSchemeAndHttpHost())
-      ) {
-        $value['uri'] = LinkitHelper::uriFromUserInput($value['uri']);
-      }
-      $value += ['options' => []];
-    }
-    return $values;
   }
 
   /**


### PR DESCRIPTION
Make sure all required modules are up to date:

- `composer update drupal/helfi_proxy drupal/helfi_api_base` (proxy should be at least version 2.1.0 and api_base should be 2.0.1)
- `drush updb`

Add a link to a non-existent page with same domain using CKEditor. For example if you're testing this on SOTE: `https://helfi-sote.docker.so/rekry/test`. 

The link should be converted to `/rekry/test` (the domain part is removed) and it should *not* contain a proxy path (like `/fi/sosiaali-ja-terveyspalvelut`).
