### PR TITLE
UHF-4064: Refactored site settings form.

### DIFF
--- a/modules/hdbt_admin_tools/src/Form/SiteSettings.php
+++ b/modules/hdbt_admin_tools/src/Form/SiteSettings.php
@@ -7,8 +7,16 @@ namespace Drupal\hdbt_admin_tools\Form;
  * Contains Drupal\hdbt_admin_tools\Form\SiteSettings.
  */
 
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\language\Config\LanguageConfigOverride;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\language\ConfigurableLanguageManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Site settings.
@@ -16,6 +24,39 @@ use Drupal\Core\Form\FormStateInterface;
 class SiteSettings extends ConfigFormBase {
 
   const COLOR_PALETTE_CACHE = 'hdbt_admin_tools:theme_color';
+  const SITE_SETTINGS_CONFIGURATION = 'hdbt_admin_tools.site_settings';
+
+  /**
+   * The configurable language manager.
+   *
+   * @var \Drupal\language\ConfigurableLanguageManagerInterface
+   */
+  protected ConfigurableLanguageManagerInterface $languageManager;
+
+  /**
+   * The configuration name.
+   *
+   * @var string
+   */
+  protected string $configName = self::SITE_SETTINGS_CONFIGURATION;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, ConfigurableLanguageManagerInterface $language_manager) {
+    parent::__construct($config_factory);
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('language_manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -38,7 +79,7 @@ class SiteSettings extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildForm($form, $form_state);
-    $settings = $this->config('hdbt_admin_tools.site_settings');
+    $settings = $this->getSiteSettings();
 
     $form['#tree'] = TRUE;
     $form['#prefix'] = '<div class="layer-wrapper">';
@@ -131,6 +172,26 @@ class SiteSettings extends ConfigFormBase {
   }
 
   /**
+   * Get site settings based on current language.
+   *
+   * @return \Drupal\Core\Config\ImmutableConfig|\Drupal\Core\Config\Config|\Drupal\language\Config\LanguageConfigOverride
+   *   Returns site settings configuration based on language.
+   */
+  protected function getSiteSettings(): ImmutableConfig|Config|LanguageConfigOverride {
+    if (
+      $this->languageManager->getDefaultLanguage()->getId() !==
+      $this->languageManager->getCurrentLanguage()->getId()
+    ) {
+      return $this->languageManager->getLanguageConfigOverride(
+        $this->languageManager->getCurrentLanguage()->getId(),
+        $this->configName
+      );
+    }
+
+    return $this->config($this->configName);
+  }
+
+  /**
    * Get color palettes.
    *
    * @return array
@@ -164,7 +225,7 @@ class SiteSettings extends ConfigFormBase {
       return $cached->data;
     }
 
-    $settings = \Drupal::config('hdbt_admin_tools.site_settings');
+    $settings = \Drupal::config(self::SITE_SETTINGS_CONFIGURATION);
     if ($value = $settings->get('site_settings.theme_color')) {
       \Drupal::cache()->set(static::COLOR_PALETTE_CACHE, $value);
       return $value;
@@ -177,12 +238,38 @@ class SiteSettings extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     parent::submitForm($form, $form_state);
-    $settings = $this->configFactory->getEditable('hdbt_admin_tools.site_settings');
-    $settings->set('site_settings', $form_state->getValue('site_settings'))->save();
-    $settings->set('footer_settings', $form_state->getValue('footer_settings'))->save();
 
-    // Flush all caches when settings have been saved.
-    drupal_flush_all_caches();
+    // Save site settings (koro, color and icon) to all languages.
+    foreach ($this->languageManager->getLanguages() as $language) {
+      $this->saveConfiguration('site_settings', $form_state, $language);
+    }
+
+    // Save the footer settings to current language only.
+    $this->saveConfiguration('footer_settings', $form_state, $this->languageManager->getCurrentLanguage());
+  }
+
+  /**
+   * Save configuration.
+   *
+   * @param string $setting
+   *   Setting name as a string.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Current form state.
+   * @param \Drupal\Core\Language\LanguageInterface $language
+   *   Language to be handled.
+   */
+  protected function saveConfiguration(string $setting, FormStateInterface $form_state, LanguageInterface $language) {
+
+    // Check whether the handled language is site default language and
+    // save the configuration as default language or translation.
+    $settings = ($this->languageManager->getDefaultLanguage()->getId() === $language->getId())
+      ? $this->configFactory->getEditable($this->configName)
+      : $this->languageManager->getLanguageConfigOverride($language->getId(), $this->configName);
+
+    $settings->set($setting, $form_state->getValue($setting))->save();
+
+    // Invalidate caches.
+    Cache::invalidateTags($settings->getCacheTags());
   }
 
 }


### PR DESCRIPTION
# Fix saving site settings (koro, color-palette and icon) [UHF-4064](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4064)
Saving of the site settings didn't work correctly before. Fixed that so that koro, color-palette and icon are correctly saved and applied.

## What was done
* Refactored site settings form.

## How to install
* Check instructions from https://github.com/City-of-Helsinki/drupal-hdbt/pull/261

## How to test
* Check instructions from https://github.com/City-of-Helsinki/drupal-hdbt/pull/261

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/261
