### PR TITLE
UHF-X Gin theme lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/admin_toolbar": "^2.3",
-        "drupal/gin": "^3.0"
+        "drupal/gin": "3.0.0-alpha37"
     }
 }


### PR DESCRIPTION
# Gin theme lock
Locked gin theme to 3.0.0-alpha37 as it needs some TLC before updating to beta.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-X_gin_theme_lock`

## How to test
* Check your instance composer.lock for drupal/gin theme and make sure it's  3.0.0-alpha37
