### PR TITLE
Added Sortable as a dependency for the overridden select2 library

### DIFF
--- a/hdbt_admin.libraries.yml
+++ b/hdbt_admin.libraries.yml
@@ -12,6 +12,7 @@ select2.min:
   dependencies:
     - core/jquery.once
     - core/drupal
+    - core/sortable
 
 language-switcher:
   js:


### PR DESCRIPTION
# Depend on sortable [UHF-4983](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4983)

## How to install
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-4983_sortable`
* Run `make drush-cr`

## How to test
* Test the announcement creation for TPR units / services
