### PR TITLE
UHF-4847: Fix layout issue on group content creation form

### DIFF
--- a/config/install/block.block.language_switcher_admin.yml
+++ b/config/install/block.block.language_switcher_admin.yml
@@ -20,5 +20,5 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/node/*\r\n/admin/content/integrations/tpr-unit/*/edit\r\n/admin/content/integrations/tpr-service/*/edit"
+    pages: "/node/*\r\n/admin/content/integrations/tpr-unit/*/edit\r\n/admin/content/integrations/tpr-service/*/edit\r\n/group/*/content/create/*"
     negate: true

--- a/templates/page/page--group.html.twig
+++ b/templates/page/page--group.html.twig
@@ -1,1 +1,1 @@
-{% extends '@hdbt_admin/page/page.html.twig' %}
+{% extends '@hdbt_admin/page/page--node.html.twig' %}


### PR DESCRIPTION
# Fix layout issue on group content creation form [UHF-4847](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4847)
Fix layout issue on group content creation from where the sidebar would go under content when adding new content to group.

## What was done
* Changed the page--group template to extend correct template and removed the language switcher from the group content creation page since it isn't available on the regular content creation page either.

## How to install
* You can only test this in KASKO since the group functionality is enabled only there currently.
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the hdbt_admin and helfi_platform_config
    * `composer require drupal/hdbt_admin:dev-UHF-4847_admin_theme_fixes_for_groups`
    * `composer require drupal/helfi_platform_config:dev-UHF-4847_admin_theme_fixes_for_groups`
* Run `make drush-updb && make drush-cr`

## How to test
* Go to `/admin/group` -> Add group.
  * Add group name, e.g. "Ressun lukio -ryhmä".
* Create a front page for the new school group.
  * From the group page -> Nodes -> Add new content.
* Now on this edit form you should make sure that the sidebar is in its correct place and that the language switcher is not visible on the header. Thats all there is really.

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/294
