### PR TITLE
UHF-2915 ckeditor link title attribute default value

### DIFF
--- a/modules/hdbt_admin_editorial/assets/js/linkPluginEnhancements.js
+++ b/modules/hdbt_admin_editorial/assets/js/linkPluginEnhancements.js
@@ -49,7 +49,7 @@
         // If user has selected text before the link exists, apply the
         // selected text from global variable to current link text input field.
         const textInput = $('form.editor-link-dialog input[data-drupal-selector="edit-attributes-data-link-text"]');
-        if (!textInput.val() && window.drupalLinkTextSelection !== '') {
+        if (!textInput.val() && window.drupalLinkTextSelection !== undefined){
           textInput.val(window.drupalLinkTextSelection);
         }
       }

--- a/modules/hdbt_admin_editorial/assets/js/plugins/hds-button/plugin.js
+++ b/modules/hdbt_admin_editorial/assets/js/plugins/hds-button/plugin.js
@@ -75,11 +75,11 @@
 
       // Act only if link element is being handled.
       if (!linkElement || !linkElement.$) {
-
         // Save selected text to global variable.
-        if (editor.getSelectedHtml().$.textContent) {
-          window.drupalLinkTextSelection = editor.getSelectedHtml().$.textContent;
-        }
+        window.drupalLinkTextSelection = editor.getSelectedHtml().$.textContent
+          ? editor.getSelectedHtml().$.textContent
+          : undefined;
+
         return;
       }
 

--- a/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
+++ b/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
@@ -292,7 +292,7 @@ function hdbt_admin_editorial_form_editor_link_dialog_alter(&$form, FormStateInt
     '#description' => t(
       'Populates the title attribute of the link, usually shown as a small tooltip on hover.'
     ),
-    '#default_value' => $get_default_value('title'),
+    '#default_value' => '',
     '#maxlength' => 512,
     '#group' => 'advanced',
   ];


### PR DESCRIPTION
# Ckeditor link-modal title-attribute  -fields default value [UHF-2915](https://helsinkisolutionoffice.atlassian.net/browse/UHF-2915)
When adding or editing link on ckeditor, prevent title-attribute from being autocompleted in any situation

## What was done
* Removed default value from link's title-attribute field's definition
* (Bonus bug fix) Prevent the actual title field from being autocompleted with invalid value if multiple links are created one after another without page load in between. 

## How to install
* Can be tested in any environment
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-2915_ckeditor_link_title_attribute_default_value`
* Run `make drush-cr`

## How to test
* Go to any content (edit or create new)
* Create or edit any text-paragraph with ckeditor in it
* Add a link by clicking the link button in ckeditor header: add an url & title & attribute-title -> save the link

* create another link by clicking the link button in ckeditor header
  * (Bugfix) The first title field should be empty (used to be pre-filled with the title from the first link)
* open the advanced section in the link modal
  * the title-attribute field should be empty


## Other PRs
* 
