### PR TITLE
UHF-5662: Hid hero description if hero with search is selected

### DIFF
--- a/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
+++ b/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
@@ -133,6 +133,7 @@ function hdbt_admin_editorial_form_taxonomy_term_form_alter(array &$form, FormSt
  *   with-image-right     = "Image on the right"
  *   without-image-center = "Without image, align center"
  *   without-image-left   = "Without image, align left"
+ *   with-search          = "With search"
  */
 function hdbt_admin_editorial_field_widget_paragraphs_form_alter(&$element, &$form_state, $context) {
 
@@ -146,6 +147,8 @@ function hdbt_admin_editorial_field_widget_paragraphs_form_alter(&$element, &$fo
     $element['subform']['field_hero_desc']['#states'] = [
       'invisible' => [
         [$design_select => ['value' => 'background-image']],
+        'or',
+        [$design_select => ['value' => 'with-search']],
       ],
     ];
 


### PR DESCRIPTION
# Hero with search [UHF-5662](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5662)


## What was done
* Hides the hero description field if hero with search is selected

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-5662-hero-with-search`
* Run `make drush-cr`

## How to test
* See this PR for instructions
