### PR TITLE
UHF-5992: Link target

### DIFF
--- a/modules/hdbt_admin_editorial/hdbt_admin_editorial.install
+++ b/modules/hdbt_admin_editorial/hdbt_admin_editorial.install
@@ -111,3 +111,51 @@ function hdbt_admin_editorial_update_9003() {
     }
   }
 }
+
+/**
+ * Reconstruct CKEditor generated links with misinterpreted target values.
+ */
+function hdbt_admin_editorial_update_9004() {
+  // Search and replace following data.
+  $data_to_be_converted = [
+    'target="0"' => '',
+    'target_check="0"' => '',
+    'title=""' => '',
+  ];
+
+  $entity_type_manager = Drupal::entityTypeManager();
+  $field_storage = $entity_type_manager->getStorage('field_config');
+
+  // Load all field configurations.
+  /** @var \Drupal\field\Entity\FieldConfig $field_config */
+  foreach ($field_storage->loadMultiple() as $field_config) {
+
+    // Go through each field and check for long text fields (html formatted).
+    if ($field_config->getType() === 'text_long') {
+      $field_storage_definition = $field_config->getFieldStorageDefinition();
+      $entity_type = $field_config->getTargetEntityTypeId();
+
+      /** @var \Drupal\Core\Entity\Sql\DefaultTableMapping $table_mapping */
+      $table_mapping = $entity_type_manager->getStorage($entity_type)->getTableMapping();
+
+      // Get current field's table name and column.
+      $table_name = $table_mapping->getDedicatedDataTableName($field_storage_definition);
+      $column = $table_mapping->getFieldColumnName($field_storage_definition,'value');
+
+      // Go through our data array, treat array key as data to search for
+      // and array value as replacement. Use sql replace to replace the data.
+      foreach ($data_to_be_converted as $old => $new) {
+        $query = Drupal::database()->update($table_name);
+        $query->expression(
+          $column,
+          "REPLACE($column, :old_value, :new_value)",
+          [
+            ':old_value' => $old,
+            ':new_value' => $new,
+          ]
+        );
+        $result = $query->execute();
+      }
+    }
+  }
+}

--- a/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
+++ b/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
@@ -359,6 +359,13 @@ function _hdbt_admin_editorial_attributes_validate(array &$form, FormStateInterf
     }
   }
 
+  // Remove empty values to prevent rendering them in markup.
+  foreach (['target', 'target_check', 'title'] as $attribute) {
+    if (isset($attributes[$attribute]) && empty($attributes[$attribute])) {
+      $form_state->setValue(['attributes', $attribute], FALSE);
+    }
+  }
+
   // If the accessibility consent is not accepted,
   // uncheck the open in new window / tab checkbox.
   if ($attributes['target'] && !$attributes['target_check']) {
@@ -372,29 +379,27 @@ function _hdbt_admin_editorial_attributes_validate(array &$form, FormStateInterf
 
     // Check if current link is external (not whitelisted) and
     // set data attributes accordingly.
-    if ($url instanceof Url) {
-      /** @var \Drupal\helfi_api_base\Link\InternalDomainResolver $resolver */
-      $resolver = \Drupal::service('helfi_api_base.internal_domain_resolver');
-      $is_external = $resolver->isExternal($url);
+    /** @var \Drupal\helfi_api_base\Link\InternalDomainResolver $resolver */
+    $resolver = \Drupal::service('helfi_api_base.internal_domain_resolver');
+    $is_external = $resolver->isExternal($url);
 
-      // Set form value is-external based on domain resolver.
-      $form_state->setValue(['attributes', 'data-is-external'], $is_external ? 'true' : 'false');
+    // Set form value is-external based on domain resolver.
+    $form_state->setValue(['attributes', 'data-is-external'], $is_external ? 'true' : 'false');
 
-      // Parse URL scheme from the href attribute and set it as data variable.
-      $scheme = parse_url(($is_external) ? $url->getUri() : $attributes['href'], PHP_URL_SCHEME);
+    // Parse URL scheme from the href attribute and set it as data variable.
+    $scheme = parse_url(($is_external) ? $url->getUri() : $attributes['href'], PHP_URL_SCHEME);
 
-      // Check for tel-link.
-      $scheme = (empty($scheme) && str_contains($attributes['href'], 'tel:')) ? 'tel' : $scheme;
+    // Check for tel-link.
+    $scheme = (empty($scheme) && str_contains($attributes['href'], 'tel:')) ? 'tel' : $scheme;
 
-      // Construct a protocol value for external links if user has not selected
-      // any value for the protocol.
-      if ($is_external && empty($scheme) && $attributes['data-protocol'] === 'false') {
-        $scheme = ($scheme === 'https' || $scheme === 'http') ? $scheme . '://' : $scheme;
-      }
-
-      // Set scheme to data-protocol attribute.
-      $form_state->setValue(['attributes', 'data-protocol'], !(empty($scheme)) ? $scheme : 'false');
+    // Construct a protocol value for external links if user has not selected
+    // any value for the protocol.
+    if ($is_external && empty($scheme) && $attributes['data-protocol'] === 'false') {
+      $scheme = ($scheme === 'https' || $scheme === 'http') ? $scheme . '://' : $scheme;
     }
+
+    // Set scheme to data-protocol attribute.
+    $form_state->setValue(['attributes', 'data-protocol'], !(empty($scheme)) ? $scheme : 'false');
   }
 }
 

--- a/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
+++ b/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
@@ -136,6 +136,11 @@ function hdbt_admin_editorial_form_taxonomy_term_form_alter(array &$form, FormSt
  */
 function hdbt_admin_editorial_field_widget_paragraphs_form_alter(&$element, &$form_state, $context) {
 
+  // Early return if paragraph type is not set.
+  if (!isset($element['#paragraph_type'])) {
+    return;
+  }
+
   // Perform alterations to Hero paragraph.
   if ($element['#paragraph_type'] == 'hero') {
 

--- a/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
+++ b/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
@@ -9,7 +9,6 @@ use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Url;
 use Drupal\hdbt_admin_tools\Form\SiteSettings;
 use Drupal\helfi_api_base\Link\UrlHelper;
 use Drupal\select2_icon\Plugin\Field\FieldType\Select2Icon;


### PR DESCRIPTION
# [UHF-5992](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)

## What was done
* Fixed CKEditor link targets when saving the link
* Added an update hook to fix all wrongly targeted links from all text_long fields ( `target="0"` )

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-5992_link_target`
* Run `make drush-cr`

## How to test
* Go to edit any page with CKEditor
* Add new links with the CKEditor link tool
* Save the page and check the markup for faulty `target="0"`
