### PR TITLE
UHF-6006: User access

### DIFF
--- a/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
+++ b/modules/hdbt_admin_editorial/hdbt_admin_editorial.module
@@ -6,12 +6,15 @@
  */
 
 use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Url;
 use Drupal\hdbt_admin_tools\Form\SiteSettings;
 use Drupal\helfi_api_base\Link\UrlHelper;
 use Drupal\select2_icon\Plugin\Field\FieldType\Select2Icon;
+use Drupal\user\UserInterface;
 
 /**
  * Register routes to apply Gin’s content edit form layout.
@@ -573,4 +576,24 @@ function hdbt_admin_editorial_entity_presave($entity) {
 function hdbt_admin_editorial_ckeditor_css_alter(array &$css) {
   $css[] = Drupal::service('extension.list.theme')
     ->getPath('hdbt_admin') . '/dist/css/ckeditor.min.css';
+}
+
+/**
+ * Implements hook_entity_operation().
+ *
+ * Add update password operation to users list action list.
+ */
+function hdbt_admin_editorial_entity_operation(EntityInterface $entity) {
+  if (
+    $entity instanceof UserInterface &&
+    \Drupal::currentUser()->hasPermission('administer users')
+  ) {
+    $operations = [];
+    $operations['update_password'] = [
+      'title' => t('Update user password', [], ['context' => 'HDBT Admin editorial - One-time login link']),
+      'url' => Url::fromRoute('hdbt_admin_editorial.user_login_link', ['user' => $entity->id()]),
+      'weight' => 50,
+    ];
+    return $operations;
+  }
 }

--- a/modules/hdbt_admin_editorial/hdbt_admin_editorial.routing.yml
+++ b/modules/hdbt_admin_editorial/hdbt_admin_editorial.routing.yml
@@ -1,0 +1,10 @@
+hdbt_admin_editorial.user_login_link:
+  path: '/user/{user}/login-link'
+  defaults:
+    _form: 'Drupal\hdbt_admin_editorial\Form\UserLoginLink'
+    _title: 'Reset password'
+  requirements:
+    _permission: 'administer users'
+    _csrf_token: 'TRUE'
+  options:
+    _admin_route: TRUE

--- a/modules/hdbt_admin_editorial/src/Form/UserLoginLink.php
+++ b/modules/hdbt_admin_editorial/src/Form/UserLoginLink.php
@@ -30,13 +30,19 @@ class UserLoginLink extends FormBase {
 
       $values = $form_state->getValues();
 
+      $form['title'] = [
+        '#markup' => "<h2>{$this->t('One-time login link for %user_name', ['%user_name' => $user->getAccountName()], ['context' => 'HDBT Admin editorial - One-time login link'])}</h2>",
+      ];
+
+      $form['message'] = [
+        '#markup' =>
+          "<p>{$this->t('<strong>Do not send the one time link via MS Teams</strong> or any other instant messaging application!<br />Doing so will invalidate the login link, and it will become useless.', [], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>" .
+          "<p>{$this->t('Copy and send the one-time login link to the user via <strong>email</strong>.', [], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>"
+      ];
+
       if (empty($values)) {
-        $form['message'] = [
-          '#markup' => '<p>' . $this->t(
-            'Click the button below to generate a one-time login link for <strong>%user_name</strong>.',
-            ['%user_name' => $user->getAccountName()],
-            ['context' => 'HDBT Admin editorial - One-time login link']
-          ) . '</p>',
+        $form['submit_instructions'] = [
+          '#markup' => "<p>{$this->t('Click the button below to generate a one-time login link for <strong>%user_name</strong>.', ['%user_name' => $user->getAccountName()], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>"
         ];
 
         $form['actions']['submit'] = [
@@ -45,20 +51,12 @@ class UserLoginLink extends FormBase {
         ];
       }
       else {
-        $form['title'] = [
-          '#markup' => '<h2>' . $this->t('One-time login link for %user_name', [
-            '%user_name' => $values['user_name'],
-          ], ['context' => 'HDBT Admin editorial - One-time login link']) . '</h2>',
+        $form['time_limit'] = [
+          '#markup' => "<p>{$this->t("This link is valid for %hr. Do not visit the URL yourself as it will invalidate the login link.", ['%hr' => $this->config('user.settings')->get('password_reset_timeout') / 3600 . 'h'], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>",
         ];
 
         $form['link'] = [
-          '#markup' => '<p><code>' . $values['login_url'] . '</code></p>',
-        ];
-
-        $form['time_limit'] = [
-          '#markup' => '<p>' . $this->t("This link is valid for %hr. Do not visit the URL yourself as it will invalidate the login link.", [
-            '%hr' => $values['time_limit'] / 3600 . 'h',
-          ], ['context' => 'HDBT Admin editorial - One-time login link']) . '</p>',
+          '#markup' => "<p><code>{$values['login_url']}</code></p>",
         ];
       }
     }
@@ -79,7 +77,6 @@ class UserLoginLink extends FormBase {
     $user = $form_state->get('account');
     $form_state->setValue('user_name', $user->getAccountName());
     $form_state->setValue('login_url', user_pass_reset_url($form_state->get('account')));
-    $form_state->setValue('time_limit', $this->config('user.settings')->get('password_reset_timeout'));
   }
 
 }

--- a/modules/hdbt_admin_editorial/src/Form/UserLoginLink.php
+++ b/modules/hdbt_admin_editorial/src/Form/UserLoginLink.php
@@ -36,13 +36,13 @@ class UserLoginLink extends FormBase {
 
       $form['message'] = [
         '#markup' =>
-          "<p>{$this->t('<strong>Do not send the one time link via MS Teams</strong> or any other instant messaging application!<br />Doing so will invalidate the login link, and it will become useless.', [], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>" .
-          "<p>{$this->t('Copy and send the one-time login link to the user via <strong>email</strong>.', [], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>"
+        "<p>{$this->t('<strong>Do not send the one time link via MS Teams</strong> or any other instant messaging application!<br />Doing so will invalidate the login link, and it will become useless.', [], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>" .
+        "<p>{$this->t('Copy and send the one-time login link to the user via <strong>email</strong>.', [], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>",
       ];
 
       if (empty($values)) {
         $form['submit_instructions'] = [
-          '#markup' => "<p>{$this->t('Click the button below to generate a one-time login link for <strong>%user_name</strong>.', ['%user_name' => $user->getAccountName()], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>"
+          '#markup' => "<p>{$this->t('Click the button below to generate a one-time login link for <strong>%user_name</strong>.', ['%user_name' => $user->getAccountName()], ['context' => 'HDBT Admin editorial - One-time login link'])}</p>",
         ];
 
         $form['actions']['submit'] = [

--- a/modules/hdbt_admin_editorial/src/Form/UserLoginLink.php
+++ b/modules/hdbt_admin_editorial/src/Form/UserLoginLink.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\hdbt_admin_editorial\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Provides the form for reset the chosen user password.
+ *
+ * @package Drupal\hdbt_admin_editorial\Form
+ */
+class UserLoginLink extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'user_login_link_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, AccountInterface $user = NULL): array {
+    if ($user) {
+      $form_state->set('account', $user);
+      $form['#title'] = $this->t('Reset password');
+
+      $values = $form_state->getValues();
+
+      if (empty($values)) {
+        $form['message'] = [
+          '#markup' => '<p>' . $this->t(
+            'Click the button below to generate a one-time login link for <strong>%user_name</strong>.',
+            ['%user_name' => $user->getAccountName()],
+            ['context' => 'HDBT Admin editorial - One-time login link']
+          ) . '</p>',
+        ];
+
+        $form['actions']['submit'] = [
+          '#type' => 'submit',
+          '#value' => $this->t('Generate the URL', [], ['context' => 'HDBT Admin editorial - One-time login link']),
+        ];
+      }
+      else {
+        $form['title'] = [
+          '#markup' => '<h2>' . $this->t('One-time login link for %user_name', [
+            '%user_name' => $values['user_name'],
+          ], ['context' => 'HDBT Admin editorial - One-time login link']) . '</h2>',
+        ];
+
+        $form['link'] = [
+          '#markup' => '<p><code>' . $values['login_url'] . '</code></p>',
+        ];
+
+        $form['time_limit'] = [
+          '#markup' => '<p>' . $this->t("This link is valid for %hr. Do not visit the URL yourself as it will invalidate the login link.", [
+            '%hr' => $values['time_limit'] / 3600 . 'h',
+          ], ['context' => 'HDBT Admin editorial - One-time login link']) . '</p>',
+        ];
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    if (!$form_state->get('account')->id()) {
+      $this->messenger()->addError($this->t('There was an error with the account.'));
+      return;
+    }
+
+    $form_state->setRebuild();
+    $user = $form_state->get('account');
+    $form_state->setValue('user_name', $user->getAccountName());
+    $form_state->setValue('login_url', user_pass_reset_url($form_state->get('account')));
+    $form_state->setValue('time_limit', $this->config('user.settings')->get('password_reset_timeout'));
+  }
+
+}

--- a/modules/hdbt_admin_editorial/translations/fi.po
+++ b/modules/hdbt_admin_editorial/translations/fi.po
@@ -100,3 +100,23 @@ msgstr "Avaa uudessa ikkunassa / välilehdellä"
 
 msgid "The link meets the accessibility requirements"
 msgstr "Linkki täyttää saavutettavuusvaatimukset"
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "Click the button below to generate a one-time login link for <strong>%user_name</strong>."
+msgstr "Klikkaa alla olevaa painiketta luodaksesi kertakäyttöisen kirjautumislinkin käyttäjälle <strong>%user_name</strong>."
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "Generate the URL"
+msgstr "Generoi URL-osoite"
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "One-time login link for %user_name"
+msgstr "Kertakäyttöinen kirjautumislinkki käyttäjälle %user_name"
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "This link is valid for %hr. Do not visit the URL yourself as it will invalidate the login link."
+msgstr "Tämä linkki on voimassa %hr. Älä käy URL-osoitteessa itse, sillä se mitätöi kirjautumislinkin."
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "Update user password"
+msgstr "Päivitä käyttäjän salasana"

--- a/modules/hdbt_admin_editorial/translations/fi.po
+++ b/modules/hdbt_admin_editorial/translations/fi.po
@@ -102,16 +102,24 @@ msgid "The link meets the accessibility requirements"
 msgstr "Linkki täyttää saavutettavuusvaatimukset"
 
 msgctxt "HDBT Admin editorial - One-time login link"
+msgid "One-time login link for %user_name"
+msgstr "Kertakäyttöinen kirjautumislinkki käyttäjälle %user_name"
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "<strong>Do not send the one time link via MS Teams</strong> or any other instant messaging application!<br />Doing so will invalidate the login link, and it will become useless."
+msgstr "<strong>Älä lähetä kertakäyttöistä linkkiä MS Teamsin kautta</strong> tai minkään muun pikaviestisovelluksen kautta!<br />Pikaviestimet lataavat URL-osoitteen esikatseluun ja tämä toimenpide mitätöi kirjautumislinkin."
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "Copy and send the one-time login link to the user via <strong>email</strong>."
+msgstr "Kopioi Kertakäyttöinen kirjautumislinkki ja lähetä se käyttäjälle <strong>sähköpostitse</strong>"
+
+msgctxt "HDBT Admin editorial - One-time login link"
 msgid "Click the button below to generate a one-time login link for <strong>%user_name</strong>."
 msgstr "Klikkaa alla olevaa painiketta luodaksesi kertakäyttöisen kirjautumislinkin käyttäjälle <strong>%user_name</strong>."
 
 msgctxt "HDBT Admin editorial - One-time login link"
 msgid "Generate the URL"
 msgstr "Generoi URL-osoite"
-
-msgctxt "HDBT Admin editorial - One-time login link"
-msgid "One-time login link for %user_name"
-msgstr "Kertakäyttöinen kirjautumislinkki käyttäjälle %user_name"
 
 msgctxt "HDBT Admin editorial - One-time login link"
 msgid "This link is valid for %hr. Do not visit the URL yourself as it will invalidate the login link."

--- a/modules/hdbt_admin_editorial/translations/sv.po
+++ b/modules/hdbt_admin_editorial/translations/sv.po
@@ -9,16 +9,24 @@ msgid "Hide sidebar navigation from this page"
 msgstr "Dölj sidofältsnavigering från den här sidan"
 
 msgctxt "HDBT Admin editorial - One-time login link"
+msgid "One-time login link for %user_name"
+msgstr "Engångsinloggningslänk för %user_name"
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "<strong>Do not send the one time link via MS Teams</strong> or any other instant messaging application!<br />Doing so will invalidate the login link, and it will become useless."
+msgstr "<strong>Skicka inte engångslänken via MS Teams</strong> eller något annat program för snabbmeddelanden!<br />Om du gör det ogiltigförklaras inloggningslänken och den blir värdelös."
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "Copy and send the one-time login link to the user via <strong>email</strong>."
+msgstr "Kopiera och skicka engångsinloggningslänken till användaren via <strong>e-post</strong>."
+
+msgctxt "HDBT Admin editorial - One-time login link"
 msgid "Click the button below to generate a one-time login link for <strong>%user_name</strong>."
 msgstr "Klicka på knappen nedan för att skapa en engångsinloggningslänk för <strong>%user_name</strong>."
 
 msgctxt "HDBT Admin editorial - One-time login link"
 msgid "Generate the URL"
 msgstr "Skapa URL:en"
-
-msgctxt "HDBT Admin editorial - One-time login link"
-msgid "One-time login link for %user_name"
-msgstr "Engångsinloggningslänk för %user_name"
 
 msgctxt "HDBT Admin editorial - One-time login link"
 msgid "This link is valid for %hr. Do not visit the URL yourself as it will invalidate the login link."

--- a/modules/hdbt_admin_editorial/translations/sv.po
+++ b/modules/hdbt_admin_editorial/translations/sv.po
@@ -7,3 +7,23 @@ msgstr "Hur ändrade du sidan?"
 
 msgid "Hide sidebar navigation from this page"
 msgstr "Dölj sidofältsnavigering från den här sidan"
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "Click the button below to generate a one-time login link for <strong>%user_name</strong>."
+msgstr "Klicka på knappen nedan för att skapa en engångsinloggningslänk för <strong>%user_name</strong>."
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "Generate the URL"
+msgstr "Skapa URL:en"
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "One-time login link for %user_name"
+msgstr "Engångsinloggningslänk för %user_name"
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "This link is valid for %hr. Do not visit the URL yourself as it will invalidate the login link."
+msgstr "Denna länk är giltig i %hr. Besök inte webbadressen själv eftersom det kommer att ogiltigförklara inloggningslänken."
+
+msgctxt "HDBT Admin editorial - One-time login link"
+msgid "Update user password"
+msgstr "Uppdatera användarlösenord"


### PR DESCRIPTION
# [UHF-6006](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6006)

## What was done
* Created a form for administrator to create one-time login links for Drupal users.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-6006_user_access`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-6006_user_access`
* Run `make drush-cr`

## How to test
* Login to any instance as Admin user (no UID1)
   * It can be done like so: `drush uli --uid=123` - just make sure that the user you're login in with has admin (Pääkäyttäjä) role.
* Once logged in, go to `/admin/people` and select "Update user password" from operations.
   ![image](https://user-images.githubusercontent.com/1712902/173856575-65cab557-a54f-45bf-8312-8ed92fb95e96.png)
  * Click on Generate URL and copy the link once the form prints it out.
  * Open a new browser or incognito window and paste the URL there. See that the login works.


## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/349
