### PR TITLE
UHF-5938: added template for rebots entry

### DIFF
--- a/templates/module/helfi_debug/debug-item--robots.html.twig
+++ b/templates/module/helfi_debug/debug-item--robots.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * To actually show any data from a custom plugin, you *MUST* override this template
+ * with a template called 'debug-item--{{ id }}.html.twig'.
+ *
+ * For example: debug-item--composer.html.twig, where 'composer' is your plugin's ID.
+ *
+ * You can then loop your data with something like this:
+ * {% for item in data.packages %}
+ *    {{ item.name }}
+ *    {{ item.version }}
+ * {% endfor %}
+ *
+ *  Available variables:
+ *  - id: The ID of your plugin
+ *  - label The label of your plugin
+ *  - data:  An array of data returned by your plugin's collect() method.
+ */
+#}
+
+<h2>Robots</h2>
+<table style="width:auto;">
+  <thead>
+  <tr>
+    <th>Key</th>
+    <th>Status</th>
+  </tr>
+  </thead>
+  <tbody>
+  {% for key, value in data %}
+    <tr>
+      <th>
+        {{ key }}
+      </th>
+      <td>
+        <span style="color: {{ color }}">
+         {{ value ? 'TRUE' : 'FALSE' }}
+        </span>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
Added template which shows rebots header status on debug page

Related PR
https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/compare/UHF-5938_robots_debug_page_entry