### PR TITLE
UHF-3238: Changed placeholder icons to use abstract icons

### DIFF
--- a/modules/hdbt_admin_tools/src/Form/SiteSettings.php
+++ b/modules/hdbt_admin_tools/src/Form/SiteSettings.php
@@ -100,12 +100,12 @@ class SiteSettings extends ConfigFormBase {
     ];
 
     $icons = [
-      'group' => $this->t('Group'),
-      'home-smoke' => $this->t('Home'),
-      'face-smile' => $this->t('Smiley'),
-      'heart-fill' => $this->t('Heart'),
-      'star-fill' => $this->t('Star'),
-      'layers' => $this->t('Layers'),
+      'abstract-1' => $this->t('Icon 1'),
+      'abstract-2' => $this->t('Icon 2'),
+      'abstract-3' => $this->t('Icon 3'),
+      'abstract-4' => $this->t('Icon 4'),
+      'abstract-5' => $this->t('Icon 5'),
+      'abstract-6' => $this->t('Icon 6'),
     ];
 
     $form['site_settings']['default_icon'] = [


### PR DESCRIPTION
# [UHF-3238](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3238)
Changed placeholder icons to use abstract icons

## What was done
* Switched the old icons for the abstract icons that design selected.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-3238_placeholder_icons`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-3238_placeholder_icons`
* Run `make drush-cr`

## How to test
* Go to `/admin/tools/site-settings` and make sure you can select the default icon from the abstract icons like in the screenshot.
* Select one, save the settings and make sure the default icon works correctly.

<img width="928" alt="Screenshot 2022-09-27 at 17 18 34" src="https://user-images.githubusercontent.com/2276077/192551961-5914b303-496a-4a5f-91fc-dd5d6862028b.png">

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/419
