### PR TITLE
UHF-7139: Remove footer top content configuration

### DIFF
--- a/modules/hdbt_admin_tools/config/install/hdbt_admin_tools.site_settings.yml
+++ b/modules/hdbt_admin_tools/config/install/hdbt_admin_tools.site_settings.yml
@@ -5,7 +5,3 @@ site_settings:
   koro: basic
 footer_settings:
   footer_color: dark
-  footer_top_content:
-    format: full_html
-    value: "<ul class=\"menu\"><li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Helsinki-info advisory service\" data-protocol=\"false\" href=\"https://www.hel.fi/kanslia/neuvonta-en/\">Helsinki-info advisory service</a></li><li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Contact information search\" data-protocol=\"false\" href=\"https://numerot.hel.fi/\">Contact information search</a></li><li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Give feedback\" data-protocol=\"false\" href=\"https://www.hel.fi/feedback/\">Give feedback</a></li></ul>\r\n"
-  footer_top_title: 'Contact us'

--- a/modules/hdbt_admin_tools/config/install/language/fi/hdbt_admin_tools.site_settings.yml
+++ b/modules/hdbt_admin_tools/config/install/language/fi/hdbt_admin_tools.site_settings.yml
@@ -1,5 +1,0 @@
-footer_settings:
-  footer_top_content:
-    format: full_html
-    value: "<ul class=\"menu\">\r\n\t<li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Kaupungin neuvonta – Helsinki-info\" data-protocol=\"false\" href=\"https://www.hel.fi/kanslia/neuvonta-fi/\">Kaupungin neuvonta – Helsinki-info</a></li>\r\n\t<li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Hae yhteystietoja ja numeroita\" data-protocol=\"false\" href=\"https://numerot.hel.fi/\">Hae yhteystietoja ja numeroita</a></li>\r\n\t<li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Anna palautetta\" data-protocol=\"false\" href=\"https://www.hel.fi/palaute\">Anna palautetta</a></li>\r\n</ul>\r\n"
-  footer_top_title: 'Ota yhteyttä'

--- a/modules/hdbt_admin_tools/config/schema/hdbt_admin_tools.schema.yml
+++ b/modules/hdbt_admin_tools/config/schema/hdbt_admin_tools.schema.yml
@@ -22,12 +22,6 @@ hdbt_admin_tools.site_settings:
         footer_color:
           label: 'Footer color'
           type: label
-        footer_top_title:
-          label: 'Footer top title'
-          type: label
-        footer_top_content:
-          label: 'Footer top content'
-          type: text_format
 
 hdbt_admin_tools.cookie_consent_intro:
   type: config_object

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.install
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.install
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Contains install functions for HDBT Admin tools.
+ */
+
+/**
+ * Remove footer top content and top title configuration.
+ */
+function hdbt_admin_tools_update_9001() {
+  $theme_handler = Drupal::service('theme_handler');
+  $config_factory = \Drupal::configFactory();
+
+  // Handle HDBT Admin.
+  if ($theme_handler->themeExists('hdbt_admin')) {
+    $hdbt_admin_tools_site_settings = $config_factory->getEditable('hdbt_admin_tools.site_settings');
+    $hdbt_admin_tools_site_settings_data = $hdbt_admin_tools_site_settings->getRawData();
+    if (!empty($hdbt_admin_tools_site_settings_data)) {
+      unset($hdbt_admin_tools_site_settings_data['footer_settings']['footer_top_content']);
+      unset($hdbt_admin_tools_site_settings_data['footer_settings']['footer_top_title']);
+      $hdbt_admin_tools_site_settings->setData($hdbt_admin_tools_site_settings_data)->save(TRUE);
+    }
+  }
+}

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -33,7 +33,6 @@ function hdbt_admin_tools_form_config_translation_form_alter(&$form, &$form_stat
     $settings = &$form['config_names']['hdbt_admin_tools.site_settings'];
 
     // Don't translate global fields.
-    $settings['footer_settings']['footer_top_content']['#open'] = TRUE;
     $settings['footer_settings']['footer_color']['#disabled'] = TRUE;
     $settings['site_settings']['koro']['#disabled'] = TRUE;
     $settings['site_settings']['theme_color']['#disabled'] = TRUE;

--- a/modules/hdbt_admin_tools/src/Form/SiteSettings.php
+++ b/modules/hdbt_admin_tools/src/Form/SiteSettings.php
@@ -154,19 +154,6 @@ class SiteSettings extends ConfigFormBase {
       '#default_value' => $settings->get('footer_settings')['footer_color'],
     ];
 
-    $form['footer_settings']['footer_top_title'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Footer top title'),
-      '#default_value' => $settings->get('footer_settings')['footer_top_title'],
-    ];
-
-    $form['footer_settings']['footer_top_content'] = [
-      '#type' => 'text_format',
-      '#format' => $settings->get('footer_settings')['footer_top_content']['format'],
-      '#title' => $this->t('Footer top content'),
-      '#default_value' => $settings->get('footer_settings')['footer_top_content']['value'],
-    ];
-
     $form['#attached']['library'][] = 'hdbt_admin_tools/site_settings';
     $form['#attached']['library'][] = 'hdbt/color-palette';
 


### PR DESCRIPTION
# UHF-7139 [UHF-7139](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7139)
Remove footer top content configuration and replace it with a real menu on instances that don't use global navigation.

## What was done
* Removed footer top content configuration form.
* Removed footer top content configuration form the configuration files.

## How to install
* Test this feature with Rekry-instance and with one instance that has global navigation enabled like for example Sote-instance.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-7139_remove_footer_top_content_configuration`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-7139_remove_footer_top_content_configuration`
* Update the helfi_navigation
    * `composer require drupal/helfi_navigation:dev-UHF-7139_remove_footer_top_content_configuration`
* Run `make drush-cr && make drush-updb && make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] The thing that should change in instances without global navigation such as Rekry is that on the footer there shouldn't be anymore visible menu with "Connect" or "Contact us" title. Instead it is now replaced with a menu called "Footer top navigation - Second".
* [ ] Go edit the Footer top navigation - Second https://helfi-rekry.docker.so/en/admin/structure/menu/manage/footer-top-navigation-2 and add some links to all languages and save. Make sure the navigation block is now visible with the links that you added to it on the footer.
* [ ] Go make sure there is no longer a settings for for footer top content and footer top title on the site settings https://helfi-rekry.docker.so/en/admin/tools/site-settings
* [ ] For the instances with global navigation the change should be only that there is no more a settings for for footer top content and footer top title on the site settings /admin/tools/site-settings and that if you export the configuration there is no more footer_top_content and footer_top_title configurations on the hdbt_admin_tools.site_settings.yml.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/474
* https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/pull/19
