### PR TITLE
UHF-7126: Run assets through file generator

### DIFF
--- a/modules/hdbt_admin_editorial/src/DesignSelectionManager.php
+++ b/modules/hdbt_admin_editorial/src/DesignSelectionManager.php
@@ -46,12 +46,16 @@ class DesignSelectionManager {
 
     $asset_path = $this->moduleHandler->getModule('hdbt_admin_editorial')->getPath() . '/assets/images';
     $images = [];
+    /** @var \Drupal\Core\File\FileUrlGeneratorInterface $service */
+    $service = \Drupal::service('file_url_generator');
 
     foreach ($selections as $selection) {
       $asset = "$asset_path/{$field_name}--$selection.svg";
-      $images[$selection] = (file_exists(DRUPAL_ROOT . '/' . $asset))
-        ? helfi_proxy_absolute_url("/$asset")
-        : helfi_proxy_absolute_url("/$asset_path/custom-style.svg");
+
+      if (!file_exists(DRUPAL_ROOT . '/' . $asset)) {
+        $asset = "$asset_path/custom-style.svg";
+      }
+      $images[$selection] = $service->generate($asset)->toString(TRUE)->getGeneratedUrl();
     }
 
     // Let modules to alter the image lists.


### PR DESCRIPTION
# [UHF-7126](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7126)
<!-- What problem does this solve? -->

## How to install

* Update the HDBT admin theme
  * `composer require drupal/hdbt_admin:dev-UHF-7126`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Make sure paragraph icons are still served through proxy asset path. For example https://kymp.docker.so/liikenne-assets/themes/xxxx/icon.svg
