### PR TITLE
Added missing hdb_admin_tools dependency

### DIFF
--- a/modules/hdbt_admin_editorial/hdbt_admin_editorial.info.yml
+++ b/modules/hdbt_admin_editorial/hdbt_admin_editorial.info.yml
@@ -5,8 +5,9 @@ package: Custom
 core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
-  - ckeditor
+  - drupal:ckeditor
   - drupal:editor
-  - linkit
+  - drupal:linkit
+  - drupal:hdbt_admin_tools
 'interface translation project': hdbt_admin_editorial
 'interface translation server pattern': themes/contrib/hdbt_admin/modules/hdbt_admin_editorial/translations/%language.po


### PR DESCRIPTION
Robot tests  seems to fail due to missing dependency: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/actions/runs/3427627080/jobs/5710862812