### PR TITLE
Remove drupal/admin_toolbar dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0+",
     "minimum-stability": "dev",
     "require": {
-        "drupal/admin_toolbar": "^2.3",
+        "drupal/admin_toolbar": "^3.0",
         "drupal/gin": "3.0.0-beta5"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "license": "GPL-2.0+",
     "minimum-stability": "dev",
     "require": {
-        "drupal/admin_toolbar": "^3.0",
         "drupal/gin": "3.0.0-beta5"
     },
     "conflict": {


### PR DESCRIPTION
Admin toolbar 2.0 is unsupported.

## What was done

* Removed `drupal/admin_toolbar` dependency since it's already required by helfi_platform_config module 

## How to install
* Update the HDBT Admin theme and platform config module
    * `composer require drupal/hdbt_admin:dev-UHF-X-update-admin-toolbar drupal/helfi_platform_config:dev-UHF-X-update-admin-toolbar -W`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure admin toolbar still works

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/472