### PR TITLE
UHF-X Freeze admin toolbar 3.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "drupal/gin": "3.0.0-rc2"
     },
     "conflict": {
-        "drupal/helfi_platform_config": "<3.0"
+        "drupal/helfi_platform_config": "<3.0",
+        "drupal/admin_toolbar": ">3.3.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "license": "GPL-2.0+",
     "minimum-stability": "dev",
     "require": {
-        "drupal/gin": "3.0.0-rc2"
+        "drupal/gin": "3.0.0-rc2",
+        "drupal/admin_toolbar": "3.3.0"
     },
     "conflict": {
         "drupal/helfi_platform_config": "<3.0",


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Freeze admin toolbar module to 3.3.0 until the [fixed accessibility issue](https://www.drupal.org/node/3286466) has been addressed also in the Gin toolbar module or Gin theme.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-X_freeze_admin_toolbar_330 -W`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the admin toolbar works as before the admin toolbar module update
   * ![image](https://user-images.githubusercontent.com/1712902/235627946-d7e801be-6c83-4eec-ac2e-7f8ff9a9ef6e.png)
* Here's how it was after the module update  
![image](https://user-images.githubusercontent.com/1712902/235626865-1346e938-33fc-46ba-8444-7d307db10f71.png)
