### PR TITLE
UHF-7426: Hide cookie banner on admin pages

### DIFF
--- a/hdbt_admin.theme
+++ b/hdbt_admin.theme
@@ -393,3 +393,10 @@ function hdbt_admin_preprocess_media(&$variables) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function hdbt_admin_preprocess_page(&$variables) {
+  $variables['#attached']['drupalSettings']['eu_cookie_compliance']['hide_the_banner'] = TRUE;
+}


### PR DESCRIPTION
# [UHF-7426](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7426)
"Fix" cookie banner broken styles. Actually hide the cookie banner on admin pages.

## What was done
Added preprocess hook for hiding the cookie banner on admin pages.
Uses the cookie banner module's built-in strategy for hiding the banner. You can check the `eu_cookie_compliance_page_attachments` function here: https://git.drupalcode.org/project/eu-cookie-compliance/-/blob/8.x-1.x/eu_cookie_compliance.module for more info.

## Test these *BEFORE* install
* `make drush uli` in the instance you're going to use for testing
* Open the log-in link in incognito tab
* Go to `https://[your instance]/en/admin/content/media`
* You *should* see cookie banner here (with broken styles)

## How to install
* Boot up an instance of your choice. Note the preliminary steps above ☝️ 
* Install this feature: `composer require drupal/hdbt_admin:dev-UHF-7426-cookie-compliance-fix`
* `make drush-cr`

## How to test

* Go to `https://[your instance]/en/admin/content/media` in your incognito tab -> cookie banner should no longer be visible
* Click around the admin pages. You should not encounter cookie banner anywhere.



[UHF-7426]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ