### PR TITLE
UHF-X: Admin toolbar update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "drupal/admin_toolbar": "^3.0"
     },
     "conflict": {
-        "drupal/helfi_platform_config": "<3.0",
-        "drupal/admin_toolbar": ">3.3.0"
+        "drupal/helfi_platform_config": "<3.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/gin": "3.0.0-rc2",
-        "drupal/admin_toolbar": "3.3.0"
+        "drupal/admin_toolbar": "^3.0"
     },
     "conflict": {
         "drupal/helfi_platform_config": "<3.0",


### PR DESCRIPTION
This admin_toolbar module was frozen to 3.3.0 due to issue with double arrows: https://www.drupal.org/node/3286466
This has now been fixed so updating to latest version. Also there was a security update that needs to be deployed everywhere.