### PR TITLE
UHF-8389: Core once

### DIFF
--- a/hdbt_admin.libraries.yml
+++ b/hdbt_admin.libraries.yml
@@ -10,7 +10,6 @@ select2.min:
     component:
       dist/css/select2.min.css: { preprocess: false }
   dependencies:
-    - core/jquery.once
     - core/drupal
     - core/sortable
 


### PR DESCRIPTION
# [UHF-8389](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8389)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed mention to Jquery.once as the Select2 library doesn't use jQuery.once

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-8389_core_once`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Check that features that uses Select 2 still works. For example:
   * [x] Color palette
    ![image](https://github.com/City-of-Helsinki/drupal-hdbt-admin/assets/1712902/ed106297-8a6d-4f1d-9d4d-027ff2387354)
   * [x] Paragraph styles / link styles 
![image](https://github.com/City-of-Helsinki/drupal-hdbt-admin/assets/1712902/14faa39a-95e2-4776-bae3-4633d263fc31)
   * [x] Icon selection 
![image](https://github.com/City-of-Helsinki/drupal-hdbt-admin/assets/1712902/377674f8-cdd4-4849-a64e-951ac5462c50)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/510


[UHF-8389]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ