### PR TITLE
UHF-9738: Hide content_translation_status published for news articles content type

### DIFF
--- a/hdbt_admin.theme
+++ b/hdbt_admin.theme
@@ -133,10 +133,15 @@ function hdbt_admin_form_node_form_alter(&$form, FormStateInterface $form_state)
     $form['gin_actions']['actions']['preview']['#access'] = FALSE;
   }
 
+  $news_content_types = [
+    'news_item',
+    'news_article',
+  ];
+
   // Don't show "menu link translation" published checkbox on news items, as
   // news items cannot be added to any menu.
   if (
-    $node->getType() === 'news_item' &&
+    in_array($node->getType(), $news_content_types) &&
     isset($form['menu']['content_translation_status'])
   ) {
     $form['menu']['content_translation_status']['#access'] = FALSE;


### PR DESCRIPTION
# [UHF-9738](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/572
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/735
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/280
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/945

[UHF-9738]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ