### PR TITLE
UHF-X Lock Gin version to RC10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0+",
     "minimum-stability": "dev",
     "require": {
-        "drupal/gin": "^3.0@rc",
+        "drupal/gin": "3.0.0-rc10",
         "drupal/admin_toolbar": "^3.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,11 @@
     "license": "GPL-2.0+",
     "minimum-stability": "dev",
     "require": {
-        "drupal/gin": "3.0.0-rc10",
+        "drupal/gin": "^3.0@rc",
         "drupal/admin_toolbar": "^3.0"
     },
     "conflict": {
+        "drupal/gin": ">3.0.0-rc10",
         "drupal/helfi_platform_config": "<4.3"
     }
 }


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Lock Gin version to RC10 until we've checked all possible issues from RC11.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-X_lock_gin_rc10 -W`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the Gin version RC10 is installed
