### PR TITLE
UHF-9950 Preview on new translations

### DIFF
--- a/hdbt_admin.theme
+++ b/hdbt_admin.theme
@@ -128,8 +128,8 @@ function hdbt_admin_form_node_form_alter(&$form, FormStateInterface $form_state)
   /** @var \Drupal\node\NodeInterface $node */
   $node = $formObject->getEntity();
 
-  // Disable "Preview" button on new nodes.
-  if ($node->isNew()) {
+  // Disable "Preview" button on new nodes and new translations.
+  if ($node->isNew() || $node->isNewTranslation()) {
     $form['gin_actions']['actions']['preview']['#access'] = FALSE;
   }
 


### PR DESCRIPTION
# [UHF-9950](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9950)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Don't show a preview button for new node translations.
  * When the user clicks the preview button for a new node or a new translation, any paragraphs or other entity references have not yet been saved/created. This is a problem in preview as the preview tries to load the entities or their revisions. It's easier to hide the Preview button for this kind of niche user behaviour than to build an entire function to display unsaved entities.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-9950`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Create a landing page with hero paragraph and save the landing page
* [x] Create a new translation for the landing page and check that there is no "Preview" button on the node translation form.
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR


[UHF-9950]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ