### PR TITLE
UHF-10657:  Show row weights

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,12 @@
         "drupal/gin": ">3.0.0-rc11",
         "drupal/helfi_platform_config": "<4.3",
         "drupal/helfi_api_base": "<2.7.6"
+    },
+    "extra": {
+        "patches": {
+            "drupal/gin": {
+                "Fix Gin show row weights button. (https://www.drupal.org/project/gin/issues/3461093)": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-hdbt-admin/ad117e1b2a3dcf1543f111533452b176456305ff/patches/gin_show_row_weights-3461093.patch"
+            }
+        }
     }
 }

--- a/patches/gin_show_row_weights-3461093.patch
+++ b/patches/gin_show_row_weights-3461093.patch
@@ -1,0 +1,14 @@
+diff --git a/js/overrides/tabledrag.js b/js/overrides/tabledrag.js
+index 2462c081f..16dd901f7 100644
+--- a/js/overrides/tabledrag.js
++++ b/js/overrides/tabledrag.js
+@@ -253,7 +253,8 @@
+         this.toggleColumns();
+       }.bind(this),
+     );
+-    if ($table.parents('.gin-table-scroll-wrapper')) {
++
++    if ($table.parents('.gin-table-scroll-wrapper').length > 0) {
+       $table.parents('.gin-table-scroll-wrapper').before($toggleWeightWrapper);
+     }
+     else {


### PR DESCRIPTION
# [UHF-10657](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10657)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added patch to fix the 'show row weights' button when dealing with paragraphs.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-10657 -W`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the "show row weights" button has reappeared
* [ ] Check that code follows our standards



[UHF-10657]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ