### PR TITLE
UHF-8650: Cookie banner

### DIFF
--- a/templates/page/page.html.twig
+++ b/templates/page/page.html.twig
@@ -77,3 +77,4 @@
     {{ page.content|without(local_actions_block) }}
   </main>
 </div>
+<footer role="contentinfo" class="footer"></footer>


### PR DESCRIPTION
# [UHF-8650](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added footer tag to page.html.twig to support the cookie banner in admin theme.

## How to install
* Make sure Etusivu or Sote instance is up and running on latest dev branch (and db from testing).
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-8650`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check from the front page that the cookie banner gets loaded
* [ ] Go to any admin page and check that the cookie banner gets loaded
* [ ] Check that code follows our standards

