### PR TITLE
UHF-X: Fix the broken link on dashboard to create new content

### DIFF
--- a/templates/views/views-view--dashboard-your-content.html.twig
+++ b/templates/views/views-view--dashboard-your-content.html.twig
@@ -50,7 +50,7 @@
       <h2>{{ 'My pages'|t({}, {'context': 'Dashboard'}) }}</h2>
       <p>{{ 'My pages include pages you have created and pages where you are the most recent editor. The list only shows pages from this instance.'|t({}, {'context': 'Dashboard'}) }}</p>
     </div>
-    <a href="/node/add" class="button button--action button--primary" data-drupal-link-system-path="node/add">{{ 'Add content'|t({}, {'context': 'Dashboard'}) }}</a>
+    {{ link('Add content'|t({}, {'context': 'Dashboard'}), 'internal:/node/add', {'class': ['button', 'button--action', 'button--primary'], 'data-drupal-link-system-path': 'node/add'}) }}
   </div>
   {% if header %}
     <div class="view-header">


### PR DESCRIPTION
# UHF-X: Fix the broken link on dashboard to create new content

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Fix the broken link on dashboard to create new content

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the HDBT Admin theme
  * `composer require drupal/hdbt_admin:dev-UHF-X_fix_broken_link_on_dashboard`
* Run code updates
  * `make drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Make sure that after you log in the link on the top right corner of the user dashboard works correctly now.
* [ ] Check that the code follows our standards.
* [ ] Check that the differences in visual regression tests are appropriate.

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->